### PR TITLE
Rename some entries of the `Checkers` hash

### DIFF
--- a/spine-test-helpers.js
+++ b/spine-test-helpers.js
@@ -281,8 +281,8 @@ export const Checkers = Object.assign(window.Checkers || {}, {
    *    className: string|undefined,
    *    innerHTML: string|undefined,
    *    innerText: string|undefined,
-   *    childNodeCheckers: Array<function>|undefined,
-   *    filteredChildNodeCheckers: Array<{filter:function,checkers:Array<function>}>|undefined,
+   *    childNodes: Array<function>|undefined,
+   *    childNodesByFilters: Array<{filter:function,checkers:Array<function>}>|undefined,
    *    slots: Object|undefined,
    *    properties: Object|undefined,
    *    computedStyle: Object|undefined,
@@ -301,13 +301,13 @@ export const Checkers = Object.assign(window.Checkers || {}, {
    *             specified string.
    *    - `innerText` makes the element's trimmed `innerText` property to be checked against the
    *             specified string.
-   *    - `childNodeCheckers` makes the element's displayed nodes to be checked with the
+   *    - `childNodes` makes the element's displayed nodes to be checked with the
    *             provided array of checkers (see the `checkNodeList` function for details, which
    *             is used to perform the actual checks). Note that only the nodes that pass the
    *             `NodePredicates.isDisplayedNode` filter are checked. Similar to
    *             `checkNodeList`, accepts an array of checker functions, one per each expected
    *             node.
-   *    - `filteredNodeCheckers` is the same as `childNodeCheckers`, but it checks a list of
+   *    - `childNodesByFilters` is the same as `childNodes`, but it checks a list of
    *             child nodes filtered according to the provided filter. In fact, it can check
    *             sets of child nodes filtered in different ways by different filters, passed
    *             here. Instead of accepting an array of checkers, it accepts an array of entries
@@ -363,12 +363,12 @@ export const Checkers = Object.assign(window.Checkers || {}, {
       assert.equal(node.innerText.trim(), params.innerText,
           `${messagePrefix}checking element's innerText`);
     }
-    if (params.childNodeCheckers !== undefined) {
-      checkNodeList(node.childNodes, null, params.childNodeCheckers,
+    if (params.childNodes !== undefined) {
+      checkNodeList(node.childNodes, null, params.childNodes,
           `${messagePrefix}checking child nodes`);
     }
-    if (params.filteredChildNodeCheckers !== undefined) {
-      params.filteredChildNodeCheckers.forEach((entry, i) => {
+    if (params.childNodesByFilters !== undefined) {
+      params.childNodesByFilters.forEach((entry, i) => {
         const nodeFilterFunction = entry.filter;
         checkNodeList(node.childNodes, nodeFilterFunction, entry.checkers,
             `${messagePrefix}checking filtered child nodes (filter index: ${i})`);


### PR DESCRIPTION
The following entries were renamed to make the code more literary and less technical:
- `Checkers.childNodeCheckers` -> `Checkers.childNodes`
- `Checkers.filteredChildNodeCheckers` -> `Checkers.childNodesByFilters`