### PR TITLE
Add new functions, revise existing ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "polymer",
     "test"
   ],
-  "version": "0.5.1",
+  "version": "0.6.0",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "polymer",
     "test"
   ],
-  "version": "0.4.0",
+  "version": "0.5.1",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/spine-test-helpers.js
+++ b/spine-test-helpers.js
@@ -348,7 +348,9 @@ export const Checkers = Object.assign(window.Checkers || {}, {
    *    innerHTML: string|undefined,
    *    innerText: string|undefined,
    *    childNodes: Array<function>|undefined,
-   *    childNodesByFilters: Array<{filter:function,checkers:Array<function>}>|undefined,
+   *    childNodesByFilters: {filter:function,checkers:Array<function>}|undefined,
+   *    shadowNodes: Array<function>|undefined,
+   *    shadowNodesByFilters: {filter:function,checkers:Array<function>}|undefined,
    *    slots: Object|undefined,
    *    properties: Object|undefined,
    *    computedStyle: Object|undefined,
@@ -373,13 +375,15 @@ export const Checkers = Object.assign(window.Checkers || {}, {
    *             `NodePredicates.isDisplayedNode` filter are checked. Similar to
    *             `checkNodeList`, accepts an array of checker functions, one per each expected
    *             node.
-   *    - `childNodesByFilters` is the same as `childNodes`, but it checks a list of
-   *             child nodes filtered according to the provided filter. In fact, it can check
-   *             sets of child nodes filtered in different ways by different filters, passed
-   *             here. Instead of accepting an array of checkers, it accepts an array of entries
-   *             where each entry is an object having two fields: `filter` (a function that
-   *             filters nodes), and `checkers` (an array of checkers that is used to check
-   *             the filtered list of child nodes — one checker per each expected node).
+   *    - `childNodesByFilter` is the same as `childNodes`, but it checks a list of
+   *             child nodes filtered according to the provided filter. This parameter accepts
+   *             an object having two fields: `filter` (a function that filters nodes), and
+   *             `checkers` (an array of checkers that is used to check the filtered list of
+   *             child nodes — one checker per each expected node).
+   *    - `shadowNodes` — same as `childNodes`, but checks element's shadow DOM nodes as received
+   *             using the element's `shadowRoot.childNodes` property.
+   *    - `shadowNodesByFilter` — same as `childNodesByFilter`, but checks element's shadow DOM
+   *             nodes as received using the element's `shadowRoot.childNodes` property.
    *    - `slots` accepts a hash that allows to run checkers on elements assigned to specific
    *             slots. Each key name in the provided hash should be the same as the slot name
    *             to be checked, and the respective value should contain a checker function that

--- a/spine-test-helpers.js
+++ b/spine-test-helpers.js
@@ -307,7 +307,7 @@ export const NodePredicates = {
  *                  An optional message that will be used in assertions performed by this
  *                  method, and passed to the respective checkers.
  */
-export function checkNodeList(nodes, nodeFilter, expectedNodeCheckers, message) {
+export function checkNodes(nodes, nodeFilter, expectedNodeCheckers, message) {
   if (!nodeFilter) {
     nodeFilter = NodePredicates.isDisplayedNode;
   }
@@ -370,10 +370,10 @@ export const Checkers = Object.assign(window.Checkers || {}, {
    *    - `innerText` makes the element's trimmed `innerText` property to be checked against the
    *             specified string.
    *    - `childNodes` makes the element's displayed nodes to be checked with the
-   *             provided array of checkers (see the `checkNodeList` function for details, which
+   *             provided array of checkers (see the `checkNodes` function for details, which
    *             is used to perform the actual checks). Note that only the nodes that pass the
    *             `NodePredicates.isDisplayedNode` filter are checked. Similar to
-   *             `checkNodeList`, accepts an array of checker functions, one per each expected
+   *             `checkNodes`, accepts an array of checker functions, one per each expected
    *             node.
    *    - `childNodesByFilter` is the same as `childNodes`, but it checks a list of
    *             child nodes filtered according to the provided filter. This parameter accepts
@@ -434,11 +434,11 @@ export const Checkers = Object.assign(window.Checkers || {}, {
           `${messagePrefix}checking element's innerText`);
     }
     if (params.childNodes !== undefined) {
-      checkNodeList(node.childNodes, null, params.childNodes,
+      checkNodes(node.childNodes, null, params.childNodes,
           `${messagePrefix}checking child nodes`);
     }
     if (params.childNodesByFilter !== undefined) {
-      checkNodeList(node.childNodes,
+      checkNodes(node.childNodes,
           params.childNodesByFilter.filter,
           params.childNodesByFilter.checkers,
           `${messagePrefix}checking child nodes filtered using a custom filter`);
@@ -446,13 +446,13 @@ export const Checkers = Object.assign(window.Checkers || {}, {
     if (params.shadowNodes !== undefined) {
       const shadowRoot = node.shadowRoot;
       assert.isOk(shadowRoot, `${messagePrefix}the element should have shadow DOM`);
-      checkNodeList(shadowRoot.childNodes, null, params.shadowNodes,
+      checkNodes(shadowRoot.childNodes, null, params.shadowNodes,
           `${messagePrefix}checking shadow DOM nodes`);
     }
     if (params.shadowNodesByFilter !== undefined) {
       const shadowRoot = node.shadowRoot;
       assert.isOk(shadowRoot, `${messagePrefix}the element should have shadow DOM`);
-      checkNodeList(shadowRoot.childNodes,
+      checkNodes(shadowRoot.childNodes,
           params.shadowNodesByFilter.filter,
           params.shadowNodesByFilter.checkers,
           `${messagePrefix}checking child nodes filtered using a custom filter`);

--- a/spine-test-helpers.js
+++ b/spine-test-helpers.js
@@ -59,6 +59,32 @@ export function testDelayed(name, testFunc, params) {
 }
 
 /**
+ * Performs an asynchronous delay with the specified duration, and resolves the returned `Promise`
+ * instance upon the completion of this period.
+ *
+ * This function can particularly be useful in [async
+ * functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function),
+ * where it can be used like this:
+ * ```
+ *    await asyncDelay(100);
+ * ```
+ *
+ * This method delays execution using the [macrotask](https://stackoverflow.com/a/25933985) queue
+ * (with the `setTimeout` function).
+ *
+ * @param {number=0} milliseconds duration of the delay in milliseconds. If omitted, this function
+ *                   creates a minimal asynchronous macrotask delay
+ * @returns {Promise<void>}
+ */
+function asyncDelay(milliseconds = 0) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve();
+    }, milliseconds);
+  });
+}
+
+/**
  * Wait for the specified condition asynchronously (with a chain of `setTimeout` invocations),
  * and invokes the provided completion callback when the condition is met. If the condition is
  * not met within the period defined by the `timeoutMillis` parameter then an assertion error is

--- a/spine-test-helpers.js
+++ b/spine-test-helpers.js
@@ -76,7 +76,7 @@ export function testDelayed(name, testFunc, params) {
  *                   creates a minimal asynchronous macrotask delay
  * @returns {Promise<void>}
  */
-function asyncDelay(milliseconds = 0) {
+export function asyncDelay(milliseconds = 0) {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve();
@@ -85,19 +85,26 @@ function asyncDelay(milliseconds = 0) {
 }
 
 /**
- * Wait for the specified condition asynchronously (with a chain of `setTimeout` invocations),
- * and invokes the provided completion callback when the condition is met. If the condition is
- * not met within the period defined by the `timeoutMillis` parameter then an assertion error is
- * reported.
+ * Performs an asynchronous delay until the specified condition is met.
+ *
+ * Fulfills the returned `Promise` if the condition is met within the period defined by the
+ * `timeoutMillis` parameter. Otherwise, rejects the `Promise`.
  *
  * A condition is specified as a function, which can return `true` or `undefined` to signify
  * that the condition is fulfilled, and return `false` or throw an exception to signify that the
  * condition is not fulfilled.
  *
- * The passed completion callback can either be invoked synchronously (if a condition is met
- * when the function is invoked), or asynchronously, if a condition is fulfilled later.
+ * Example:
+ * ```
+ * await asyncCondition(() =>
+ *   window.getElementById('status').innerText === 'Loaded!'
+ * );
+ * ```
  *
- * This function throws an exception if the specified condition wasn't fulfilled during the
+ * NOTE: the returned `Promise` can be fulfilled synchronously (if a condition is met when this
+ * function is invoked), or asynchronously (if a condition is fulfilled later).
+ *
+ * The `Promise` is rejected if the specified condition wasn't fulfilled during the
  * configured timeout period (see the `timeoutMillis` parameter).
  *
  * @param {function(): boolean|undefined} condition
@@ -105,20 +112,42 @@ function asyncDelay(milliseconds = 0) {
  *                the condition is fulfilled, and `false` if it still has to be waited for. If
  *                a function throws any exception, this is treated in the same way as if the
  *                function returned `false`.
- * @param {function}    completionCallback
  *                A function that is invoked when the condition is met.
  * @param {string=}     description
  *                An optional description that will be included into the timeout waiting failure
  *                message.
  * @param {number=2000} timeoutMillis
  *                A maximum period in milliseconds that the condition should be waited for.
+ * @returns {Promise} a `Promise`, which is either fulfilled, if the condition is met during the
+ *          allotted timeout period, and rejected otherwise.
+ */
+export function asyncCondition(condition, description, timeoutMillis = 2000) {
+  return new Promise((accept, reject) => {
+    // invoking the deprecated `waitForCondition` until its usages are removed and it is made
+    // module-private and non-deprecated again
+    // noinspection JSDeprecatedSymbols
+    waitForCondition(condition, () => {
+      accept();
+    }, description, timeoutMillis, e => {
+      reject(e);
+    });
+  });
+}
+
+/**
+ * A `Promise`less version of the `asyncCondition` method. This method is included only for
+ * backwards compatibility currently. Use the `asyncCondition` method instead.
  *
- * @throws An exception if the condition couldn't be fulfilled in the allotted timeout period.
+ * @deprecated
  */
 export function waitForCondition(condition,
     completionCallback,
     description,
-    timeoutMillis = 2000) {
+    timeoutMillis,
+    rejectionCallback) {
+  if (timeoutMillis === undefined) {
+    timeoutMillis = 2000;
+  }
   const deadline = Date.now() + timeoutMillis;
 
   let lastFailureDescription = null;
@@ -128,9 +157,15 @@ export function waitForCondition(condition,
       const lastFailureInfo = lastFailureDescription
           ? `Last failure: ${lastFailureDescription}`
           : '';
-      assert.fail('Fulfilled in time', 'Condition',
-          descriptionPrefix +
-          `Timed out waiting for a condition (in ${timeoutMillis}ms). ${lastFailureInfo}`);
+      const message = `Timed out waiting for a condition (in ${timeoutMillis}ms). ${lastFailureInfo}`;
+      if (rejectionCallback) {
+        rejectionCallback(new Error(message));
+        return;
+      } else {
+        assert.fail('Fulfilled in time', 'Condition',
+            descriptionPrefix +
+            message);
+      }
     }
     let stopWithException = null;
     try {
@@ -154,7 +189,12 @@ export function waitForCondition(condition,
     }
 
     if (stopWithException) {
-      throw stopWithException;
+      if (rejectionCallback) {
+        rejectionCallback(e);
+        return;
+      } else {
+        throw stopWithException;
+      }
     }
 
     setTimeout(() => waitFor_internal(condition, completionCallback), 20);
@@ -393,12 +433,25 @@ export const Checkers = Object.assign(window.Checkers || {}, {
       checkNodeList(node.childNodes, null, params.childNodes,
           `${messagePrefix}checking child nodes`);
     }
-    if (params.childNodesByFilters !== undefined) {
-      params.childNodesByFilters.forEach((entry, i) => {
-        const nodeFilterFunction = entry.filter;
-        checkNodeList(node.childNodes, nodeFilterFunction, entry.checkers,
-            `${messagePrefix}checking filtered child nodes (filter index: ${i})`);
-      });
+    if (params.childNodesByFilter !== undefined) {
+      checkNodeList(node.childNodes,
+          params.childNodesByFilter.filter,
+          params.childNodesByFilter.checkers,
+          `${messagePrefix}checking child nodes filtered using a custom filter`);
+    }
+    if (params.shadowNodes !== undefined) {
+      const shadowRoot = node.shadowRoot;
+      assert.isOk(shadowRoot, `${messagePrefix}the element should have shadow DOM`);
+      checkNodeList(shadowRoot.childNodes, null, params.shadowNodes,
+          `${messagePrefix}checking shadow DOM nodes`);
+    }
+    if (params.shadowNodesByFilter !== undefined) {
+      const shadowRoot = node.shadowRoot;
+      assert.isOk(shadowRoot, `${messagePrefix}the element should have shadow DOM`);
+      checkNodeList(shadowRoot.childNodes,
+          params.shadowNodesByFilter.filter,
+          params.shadowNodesByFilter.checkers,
+          `${messagePrefix}checking child nodes filtered using a custom filter`);
     }
     if (params.slots !== undefined) {
       Object.keys(params.slots).forEach(slotName => {

--- a/test/spine-test-helpers_test.html
+++ b/test/spine-test-helpers_test.html
@@ -58,7 +58,7 @@
 </test-fixture>
 
 <script type="module">
-  import { asyncDelay, asyncCondition, NodePredicates } from '../spine-test-helpers.js';
+  import {asyncDelay, asyncCondition, NodePredicates} from '../spine-test-helpers.js';
 
   /**
    * Simplifies checking the elapsed asynchronous periods while taking into account that actual

--- a/test/spine-test-helpers_test.html
+++ b/test/spine-test-helpers_test.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 
-<test-fixture id="NodePredicates-testing-cases">
+<test-fixture id="NodePredicates">
   <template>
     <!-- NOTE: Don't change the formatting of subtags here! It is a part of the test data. -->
     <div>
@@ -58,63 +58,202 @@
 </test-fixture>
 
 <script type="module">
-  import { NodePredicates } from '../spine-test-helpers.js';
+  import { asyncDelay, asyncCondition, NodePredicates } from '../spine-test-helpers.js';
 
-  suite('spine-test-helpers', function() {
+  /**
+   * Simplifies checking the elapsed asynchronous periods while taking into account that actual
+   * asynchronous delays might be somewhat longer than requested.
+   *
+   * Creating an instance starts measuring time, and invoking `assertElapsedtimeCorrect` checks the
+   * time elapsed since instance creation.
+   */
+  class AsyncDelayChecker {
+    constructor() {
+      this._startTime = Date.now();
+    }
 
-    let testCases;
+    /**
+     * Check whether time elapsed since instance creation is not less than `timeoutDelay`. This
+     * method intentionally treats periods reasonably bigger than specified as valid since
+     * JavaScript's methods such as `setTimeout` don't guarantee exact invocation times.
+     *
+     * This method can be invoked only once per instance of `AsyncDelayChecker`.
+     *
+     * @param {Number} timeoutDelay  an asynchronous delay that is expected to have passed since
+     *                               instance creation at the time when this method is invoked
+     * @param {String=} message      an optional message to include into the assertion message
+     */
+    assertElapsedTimeCorrect(timeoutDelay, message) {
+      if (this._endTime) {
+        throw new Error('This method can be invoked only once per instance');
+      }
+      this._endTime = Date.now();
+      const messagePrefix = message ? `${message}: ` : '';
+      const maxElapsedTime = timeoutDelay * 1.05 + 50;
+      expect(this._endTime - this._startTime).to.be.within(timeoutDelay, maxElapsedTime,
+        `${messagePrefix}Time elapsed is expected to be at least ${timeoutDelay}, ` +
+        `and at most${maxElapsedTime}`);
+    }
+  }
 
-    const checkNodePredicatesMethod = (methodName, positiveCasesGroup, negativeCasesGroup) => {
-      const checkCases = (nodeGroupNames, expectedPredicateValue) => {
-        nodeGroupNames.forEach(nodeGroupName => {
-          const testNodeContainers = testCases.querySelectorAll(`.${nodeGroupName} [class]`);
-          testNodeContainers.forEach(el => {
-            assert.equal(el.childNodes.length, 1,
-                'Expecting each test node container to have only one node');
-            const testedNode = el.childNodes[0];
-            const predicateValue = NodePredicates[methodName](testedNode);
-            assert.equal(predicateValue, expectedPredicateValue,
-                `Checking NodePredicates.${methodName} with ${nodeGroupName}/${el.className}`);
-          });
+  suite('spine-test-helpers', () => {
+    suite('Internal testing utilities', () => {
+      const timeoutPromise = delay => new Promise((resolve, reject) => {
+        setTimeout(() => resolve(), delay);
+      });
+
+      test('AsyncDelayChecker (positive scenarios)', async () => {
+        const checkWithDelay = async delay => {
+          const checker = new AsyncDelayChecker();
+          await timeoutPromise(delay);
+          checker.assertElapsedTimeCorrect(delay);
+        };
+        await checkWithDelay(0);
+        await checkWithDelay(50);
+        await checkWithDelay(200);
+        await checkWithDelay(500);
+
+        const noDelayChecker = new AsyncDelayChecker();
+        noDelayChecker.assertElapsedTimeCorrect(0,
+            'Synchronous execution should match a delay of 0');
+      });
+
+      test('AsyncDelayChecker (negative scenarios)', async () => {
+        const checkWithValues = async delay => {
+          const overtime = Math.ceil(delay * 1.05) + 50 + 1;
+          const checker = new AsyncDelayChecker();
+          await timeoutPromise(delay + overtime);
+          expect(() => {
+            checker.assertElapsedTimeCorrect(delay);
+          }).to.throw(Error, null, 'Expecting assertElapsedTimeCorrect to fail when checked ' +
+              `after an overtime period of ${overtime}`);
+        };
+        await checkWithValues(0);
+        await checkWithValues(50);
+        await checkWithValues(200);
+        await checkWithValues(500);
+      });
+    });
+
+    suite('Async tests helper functions', () => {
+      test('asyncDelay() delays execution by a requested amount', async () => {
+        const checkWithDelay = async delay => {
+          const timeBefore = Date.now();
+          await asyncDelay(delay);
+          const timeAfter = Date.now();
+          expect(timeAfter - timeBefore).to.be.within(delay, delay * 1.1 + 50);
+        };
+        await checkWithDelay(0);
+        await checkWithDelay(50);
+        await checkWithDelay(200);
+        await checkWithDelay(500);
+      });
+
+      test('asyncDelay(0) introduces a minimum asynchronous macrotask queue delay', async () => {
+        let taskBeforeCompleted = false;
+        let taskAfterCompleted = false;
+        setTimeout(() => {
+          taskBeforeCompleted = true;
+        }, 0);
+        const zeroDelay = asyncDelay(0);
+        setTimeout(() => {
+          taskAfterCompleted = true;
         });
+
+        await zeroDelay;
+
+        assert.isTrue(taskBeforeCompleted, 'A zero-delayed macrotask scheduled before should ' +
+            'complete by this time');
+        assert.isFalse(taskAfterCompleted, 'A zero-delayed macrotask scheduled after shouldn\'t ' +
+            'complete by this time yet');
+      });
+
+      test('asyncCondition() fulfills its Promise when a condition is met', async() => {
+        const checkWithDelay = async delay => {
+          let flag = false;
+          setTimeout(() => {
+            flag = true;
+          }, delay);
+          await asyncCondition(() => flag === true);
+          assert.isTrue(flag, 'The condition is met after asyncCondition\'s Promise is fulfilled');
+        };
+        await checkWithDelay(50);
+        await checkWithDelay(200);
+        await checkWithDelay(1000);
+      });
+
+      test('asyncCondition() rejects its Promise if a condition is not met in time', async() => {
+        const checkWithTimeout = async timeout => {
+          try {
+            await asyncCondition(() => false);
+            assert.fail('asyncCondition\'s Promise was fulfilled',
+                'asyncCondition\'s Promise should be rejected since the condition is never met');
+          } catch (e) {
+            console.log('passed');
+          }
+        };
+
+        await checkWithTimeout(50);
+        await checkWithTimeout(200);
+        await checkWithTimeout(1000);
+      });
+
+    });
+
+    suite('NodePredicates', () => {
+      let testCases;
+
+      const checkNodePredicatesMethod = (methodName, positiveCasesGroup, negativeCasesGroup) => {
+        const checkCases = (nodeGroupNames, expectedPredicateValue) => {
+          nodeGroupNames.forEach(nodeGroupName => {
+            const testNodeContainers = testCases.querySelectorAll(`.${nodeGroupName} [class]`);
+            testNodeContainers.forEach(el => {
+              assert.equal(el.childNodes.length, 1,
+                  'Expecting each test node container to have only one node');
+              const testedNode = el.childNodes[0];
+              const predicateValue = NodePredicates[methodName](testedNode);
+              assert.equal(predicateValue, expectedPredicateValue,
+                  `Checking NodePredicates.${methodName} with ${nodeGroupName}/${el.className}`);
+            });
+          });
+        };
+
+        checkCases(positiveCasesGroup, true);
+        checkCases(negativeCasesGroup, false);
       };
 
-      checkCases(positiveCasesGroup, true);
-      checkCases(negativeCasesGroup, false);
-    };
+      setup(() => {
+        testCases = fixture('NodePredicates');
+      });
 
-    setup(() => {
-      testCases = fixture('NodePredicates-testing-cases');
+      test('NodePredicates.isWhitespaceOnlyTextNode works correctly', () => {
+        checkNodePredicatesMethod('isWhitespaceOnlyTextNode', ['whitespace-nodes'], [
+          'non-empty-text-nodes', 'displayed-nodes', 'nodes-with-display-none',
+          'nodes-with-visibility-hidden', 'comment-nodes'
+        ]);
+      });
+
+      test('NodePredicates.isCommentNode works correctly', () => {
+        checkNodePredicatesMethod('isCommentNode', ['comment-nodes'], [
+          'non-empty-text-nodes', 'displayed-nodes', 'nodes-with-display-none',
+          'nodes-with-visibility-hidden', 'whitespace-nodes'
+        ]);
+      });
+
+      test('NodePredicates.isDisplayNoneElement works correctly', () => {
+        checkNodePredicatesMethod('isDisplayNoneElement', ['nodes-with-display-none'], [
+          'non-empty-text-nodes', 'displayed-nodes', 'comment-nodes',
+          'nodes-with-visibility-hidden', 'whitespace-nodes'
+        ]);
+      });
+
+      test('NodePredicates.isDisplayedNode works correctly', () => {
+        checkNodePredicatesMethod('isDisplayedNode',
+            ['non-empty-text-nodes', 'displayed-nodes', 'nodes-with-visibility-hidden'],
+            ['nodes-with-display-none', 'comment-nodes', 'whitespace-nodes']
+        );
+      });
     });
-
-    test('NodePredicates.isWhitespaceOnlyTextNode works correctly', () => {
-      checkNodePredicatesMethod('isWhitespaceOnlyTextNode', ['whitespace-nodes'], [
-        'non-empty-text-nodes', 'displayed-nodes', 'nodes-with-display-none',
-        'nodes-with-visibility-hidden', 'comment-nodes'
-      ]);
-    });
-
-    test('NodePredicates.isCommentNode works correctly', () => {
-      checkNodePredicatesMethod('isCommentNode', ['comment-nodes'], [
-        'non-empty-text-nodes', 'displayed-nodes', 'nodes-with-display-none',
-        'nodes-with-visibility-hidden', 'whitespace-nodes'
-      ]);
-    });
-
-    test('NodePredicates.isDisplayNoneElement works correctly', () => {
-      checkNodePredicatesMethod('isDisplayNoneElement', ['nodes-with-display-none'], [
-        'non-empty-text-nodes', 'displayed-nodes', 'comment-nodes',
-        'nodes-with-visibility-hidden', 'whitespace-nodes'
-      ]);
-    });
-
-    test('NodePredicates.isDisplayedNode works correctly', () => {
-      checkNodePredicatesMethod('isDisplayedNode',
-          ['non-empty-text-nodes', 'displayed-nodes', 'nodes-with-visibility-hidden'],
-          ['nodes-with-display-none', 'comment-nodes', 'whitespace-nodes']
-      );
-    });
-
   });
 </script>
 </body>

--- a/test/spine-test-helpers_test.html
+++ b/test/spine-test-helpers_test.html
@@ -88,9 +88,18 @@
         throw new Error('This method can be invoked only once per instance');
       }
       this._endTime = Date.now();
+
+      // Actual async callbacks have been noticed to arrive 1 ms earlier a couple of times in
+      // Chrome. The assumption is that this could be caused by some rounding issues, hence we
+      // consider these "earlier by 1" callbacks as valid.
+      const minElapsedTime = timeoutDelay - 1;
+
+      // allowing a fixed 50 ms of overtime below as a rough assumption of how an actual async
+      // callback's invocation time might be late relative to the scheduled invocation time
+      const maxElapsedTime = timeoutDelay + 50;
+
       const messagePrefix = message ? `${message}: ` : '';
-      const maxElapsedTime = timeoutDelay * 1.05 + 50;
-      expect(this._endTime - this._startTime).to.be.within(timeoutDelay - 1, maxElapsedTime,
+      expect(this._endTime - this._startTime).to.be.within(minElapsedTime, maxElapsedTime,
         `${messagePrefix}Time elapsed is expected to be at least ${timeoutDelay}, ` +
         `and at most ${maxElapsedTime}`);
     }
@@ -120,7 +129,9 @@
 
       test('AsyncDelayChecker (negative scenarios)', async () => {
         const checkWithValues = async delay => {
-          const overtime = Math.ceil(delay * 1.05) + 50 + 1;
+          // wait one millisecond more than 50 ms that is the maximum overtime considered as
+          // acceptable by `AsyncDelayChecker`
+          const overtime = delay + 50 + 1;
           const checker = new AsyncDelayChecker();
           await timeoutPromise(delay + overtime);
           expect(() => {
@@ -138,10 +149,10 @@
     suite('Async tests helper functions', () => {
       test('asyncDelay() delays execution by a requested amount', async () => {
         const checkWithDelay = async delay => {
-          const timeBefore = Date.now();
+          const checker = new AsyncDelayChecker();
           await asyncDelay(delay);
-          const timeAfter = Date.now();
-          expect(timeAfter - timeBefore).to.be.within(delay, delay * 1.1 + 50);
+          checker.assertElapsedTimeCorrect(delay,
+              'The actual delay should match the scheduled one');
         };
         await checkWithDelay(0);
         await checkWithDelay(50);

--- a/test/spine-test-helpers_test.html
+++ b/test/spine-test-helpers_test.html
@@ -90,9 +90,9 @@
       this._endTime = Date.now();
       const messagePrefix = message ? `${message}: ` : '';
       const maxElapsedTime = timeoutDelay * 1.05 + 50;
-      expect(this._endTime - this._startTime).to.be.within(timeoutDelay, maxElapsedTime,
+      expect(this._endTime - this._startTime).to.be.within(timeoutDelay - 1, maxElapsedTime,
         `${messagePrefix}Time elapsed is expected to be at least ${timeoutDelay}, ` +
-        `and at most${maxElapsedTime}`);
+        `and at most ${maxElapsedTime}`);
     }
   }
 


### PR DESCRIPTION
Introduces functions that can simplify writing tests written as [async functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) (these functions return `Promise` instances for them to be usable with the `await` keyword):
- `asyncDelay` — performs an asynchronous delay (can be used like `await asycDelay(100);`
- `asyncCondition` — makes an asynchronous delay until a condition is met. This is a `Promise`-based analog of an existing `waitForCondition` function, which was made deprecated in this PR.

The `checkNodeList` function was renamed to `checkNodes` to make usages more compact and avoid a dubious "list" term.

Besides, contains the following changes in the `Checkers` hash:
- The `childNodesByFilters` option of `Checkers.element` was simplified to accept only one pair of `{filter, checkers}` object, and was renamed to `childNodesByFilter` to reflect this. The multi-filter scenario is likely quite rare (if needed at all), and can be simulated with the `checkers` parameter of `Checkers.element`, if needed.
- Added `shadowNodes` and `shadowNodesbyFilter` options for `Checkers.element` function to check elements inside of element's shadow DOM.