### PR TITLE
Allow passing null/undefined entries in the list of checkers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "polymer",
     "test"
   ],
-  "version": "0.6.0",
+  "version": "0.6.1",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/spine-test-helpers.js
+++ b/spine-test-helpers.js
@@ -300,7 +300,7 @@ export const NodePredicates = {
  *                  node filtering behavior. If `null` or `undefined` is passed then
  *                  `NodePredicates.isDisplayed` is used as a default filter.
  * @param {Array<function(Node,string)>} expectedNodeCheckers
- *                  An array of checker functions. Entries with `null` or `undefined` entries are
+ *                  An array of checker functions. Entries with `null` or `undefined` values are
  *                  ignored in this array. The number of non-null, non-undefined entries is expected
  *                  to be the same as the number of checked nodes (nodes that satisfy the filtering
  *                  criteria according to `nodeFilter` value being used).

--- a/spine-test-helpers.js
+++ b/spine-test-helpers.js
@@ -300,9 +300,10 @@ export const NodePredicates = {
  *                  node filtering behavior. If `null` or `undefined` is passed then
  *                  `NodePredicates.isDisplayed` is used as a default filter.
  * @param {Array<function(Node,string)>} expectedNodeCheckers
- *                  An array of checker functions, whose length is expected to be the same as
- *                  the number of nodes that satisfy the filtering criteria according to
- *                  `nodeFilter` value being used.
+ *                  An array of checker functions. Entries with `null` or `undefined` entries are
+ *                  ignored in this array. The number of non-null, non-undefined entries is expected
+ *                  to be the same as the number of checked nodes (nodes that satisfy the filtering
+ *                  criteria according to `nodeFilter` value being used).
  * @param {string} message
  *                  An optional message that will be used in assertions performed by this
  *                  method, and passed to the respective checkers.
@@ -316,6 +317,7 @@ export function checkNodes(nodes, nodeFilter, expectedNodeCheckers, message) {
     assert.equal(nodes.length, 0, `${messagePrefix}expecting nodes list to be empty.`);
     return;
   }
+  expectedNodeCheckers = expectedNodeCheckers.filter(c => c != null);
   const filteredNodes = Array.from(nodes).filter(nodeFilter);
   assert.equal(filteredNodes.length, expectedNodeCheckers.length,
       `${messagePrefix}checking the number of nodes`);


### PR DESCRIPTION
These entries will just be ignored. This is convenient for composing lists of checkers where some content is rendered conditionally.

Before this, it was only possible to prepare a filtered smaller-size array if some content is expected to be not rendered conditionally, and now it is possible to just place null/undefined, which will just be omitted when checking the actual elements.